### PR TITLE
Normalise the catalogue data returned from the moltin API

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "normalizr": "^3.2.3",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
     "react-redux": "^5.0.6",

--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -1,3 +1,6 @@
+import { normalize } from 'normalizr';
+import * as schema from './schema';
+
 export const Update_Quantity = 'Update_Quantity';
 export const Fetch_Products_Start = 'Fetch_Products_Start';
 export const Fetch_Products_End = 'Fetch_Products_End';
@@ -40,7 +43,8 @@ export function GetProducts() {
       return api.GetProducts()
       
         .then((products) => {
-          dispatch(FetchProductsEnd(products))
+          let normalized_products = normalize(products.data, schema.arrayOfProducts);
+          dispatch(FetchProductsEnd(normalized_products))
         }) 
     }
 };
@@ -66,7 +70,8 @@ export function GetCategories() {
       return api.GetCategories()
       
         .then((categories) => {
-          dispatch(FetchCategoriesEnd(categories))
+          let normalized_categories = normalize(categories.data, schema.arrayOfCategories);
+          dispatch(FetchCategoriesEnd(normalized_categories))
         }) 
     }
 };
@@ -92,7 +97,8 @@ export function GetCollections() {
       return api.GetCollections()
       
         .then((collections) => {
-          dispatch(FetchCollectionsEnd(collections))
+          let normalized_collections = normalize(collections.data, schema.arrayOfCollections);
+          dispatch(FetchCollectionsEnd(normalized_collections))
         }) 
     }
 };

--- a/src/actions/schema.js
+++ b/src/actions/schema.js
@@ -1,0 +1,10 @@
+import { schema } from 'normalizr';
+
+export const product = new schema.Entity('products');
+export const arrayOfProducts = [ product ];
+
+export const collection = new schema.Entity('collections');
+export const arrayOfCollections = [ collection ];
+
+export const category = new schema.Entity('categories');
+export const arrayOfCategories = [ category ];

--- a/src/reducers/categories.js
+++ b/src/reducers/categories.js
@@ -14,7 +14,7 @@ const CategoriesReducer = (state=initialState, action) => {
       return {...state,
          fetching: false,
          fetched: true,
-         categories: action.payload
+         categories: action.payload.entities.categories
        };
     }
     default: {

--- a/src/reducers/collections.js
+++ b/src/reducers/collections.js
@@ -14,7 +14,7 @@ const CollectionsReducer = (state=initialState, action) => {
       return {...state,
          fetching: false,
          fetched: true,
-         collections: action.payload
+         collections: action.payload.entities.collections
        };
     }
     default: {

--- a/src/reducers/products.js
+++ b/src/reducers/products.js
@@ -14,7 +14,7 @@ const ProductsReducer = (state=initialState, action) => {
       return {...state,
          fetching: false,
          fetched: true,
-         products: action.payload
+         products: action.payload.entities.products
        };
     }
     default: {


### PR DESCRIPTION
- Adds https://github.com/paularmstrong/normalizr "Normalizr is a small, but powerful utility for taking JSON with a schema definition and returning nested entities with their IDs, gathered in dictionaries."

- Define and export schemas for products, categories and collections + their arrays in actions/schema.js. More info: https://github.com/paularmstrong/normalizr/blob/master/docs/api.md#schema

- Pass the API response data object + appropriate schema to our normalise function after the data is received from the API. More info:  https://github.com/paularmstrong/normalizr/blob/master/docs/api.md#normalizedata-schema

- Pass the normalised response to our FetchXEnd action creator where X is Products, Categories or Collections

- Set up our reducers to return new state with the normalised data.

Example of how product data was made available to the component previous to normalising:
<img width="1044" alt="screen shot 2017-08-26 at 17 51 20" src="https://user-images.githubusercontent.com/10894967/29743303-36285916-8a87-11e7-8f33-dfc0529aae1a.png">

Example of how normalised product data is made available to the component:
<img width="1294" alt="screen shot 2017-08-26 at 17 52 36" src="https://user-images.githubusercontent.com/10894967/29743308-60aead70-8a87-11e7-8364-f46b267a6191.png">
